### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- qu1queee
+- HeavyWombat
+- adambkaplan
+- sbose78
+reviewers:
+- SaschaSchwarze0
+- imjasonh
+- otaviof
+- gabemontero


### PR DESCRIPTION
Add code owners for sample-nodejs. This will enable the `/approve` prow
plugin.