### PR TITLE
Add Procfile for Heroku example

### DIFF
--- a/source-build-heroku/Procfile
+++ b/source-build-heroku/Procfile
@@ -1,0 +1,1 @@
+web: node app.js

--- a/source-build-heroku/app.js
+++ b/source-build-heroku/app.js
@@ -1,0 +1,9 @@
+// From https://github.com/homeport/gonut/tree/master/assets/sample-apps/nodejs
+
+var port = (process.env.PORT || 8080);
+var http = require('http');
+
+http.createServer(function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Hello, World!\n');
+}).listen(port);

--- a/source-build-heroku/package.json
+++ b/source-build-heroku/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "nodejs-sample-app",
+    "description": "NodeJS sample app",
+    "version": "0.0.1",
+    "engines": {
+        "node": "~20"
+    }
+}


### PR DESCRIPTION
Needed for https://github.com/shipwright-io/build/pull/1323.

Heroku does not have the ability to automatically detect which Node script to run. At least nothing is documented, and when trying it, it also does not create any processes. I am therefore adding a Procfile.

This may be something that changed in Heroku as we did not have that problem earlier and the 22 builder seems to be different based on https://github.com/heroku/builder/tree/main#heroku-builder-images.