### PR TITLE
Fix Heroku example

### DIFF
--- a/source-build-heroku/package-lock.json
+++ b/source-build-heroku/package-lock.json
@@ -1,0 +1,15 @@
+{
+    "name": "nodejs-sample-app",
+    "version": "0.0.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "nodejs-sample-app",
+            "version": "0.0.1",
+            "engines": {
+                "node": "^20.7"
+            }
+        }
+    }
+}

--- a/source-build-heroku/package.json
+++ b/source-build-heroku/package.json
@@ -3,6 +3,6 @@
     "description": "NodeJS sample app",
     "version": "0.0.1",
     "engines": {
-        "node": "~20"
+        "node": "^20.7"
     }
 }


### PR DESCRIPTION
# Changes

Changing the NodeJS example for Heroku so that it builds again. It feels like a regression in Heroku that the old code did not detect anymore. I basically now took the package.json setup from https://github.com/heroku/heroku-buildpack-nodejs/tree/main/test/fixtures/use-npm-v10.

This should address all recent red pull requests in Shipwright Build.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE
