### PR TITLE
Update node version to 18

### DIFF
--- a/source-build/package.json
+++ b/source-build/package.json
@@ -3,6 +3,6 @@
     "description": "NodeJS sample app",
     "version": "0.0.1",
     "engines": {
-        "node": "~16"
+        "node": "~18"
     }
 }


### PR DESCRIPTION
# Changes

Mitigate issues with newer Jammy stack Buildpacks builds, where Node.JS version 16 is no longer supported.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [X] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
The Node.js source build sample now references Node.js version 18.
```

