### PR TITLE
update nodejs

### DIFF
--- a/source-build-heroku/package-lock.json
+++ b/source-build-heroku/package-lock.json
@@ -8,7 +8,7 @@
             "name": "nodejs-sample-app",
             "version": "0.0.1",
             "engines": {
-                "node": "^20.7"
+                "node": "^24"
             }
         }
     }

--- a/source-build-heroku/package.json
+++ b/source-build-heroku/package.json
@@ -3,6 +3,6 @@
     "description": "NodeJS sample app",
     "version": "0.0.1",
     "engines": {
-        "node": "^20.7"
+        "node": "^24"
     }
 }


### PR DESCRIPTION
# Changes

Updated the Node.js version requirement in package.json
^24 means >=24.0.0 <25.0.0 — it allows any 24.x.x but not 25.0.0 or higher.

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes


```release-note
NONE
```
